### PR TITLE
HttpResponseForbidden if user is logged in else redirect

### DIFF
--- a/guardian/decorators.py
+++ b/guardian/decorators.py
@@ -98,6 +98,9 @@ def permission_required(perm, lookup_variables=None, **kwargs):
                     lookup_dict[lookup] = kwargs[view_arg]
                 obj = get_object_or_404(model, **lookup_dict)
 
+            if request.user.is_authenticated():
+                return_403 = True
+
             response = get_403_or_None(request, perms=[perm], obj=obj,
                 login_url=login_url, redirect_field_name=redirect_field_name,
                 return_403=return_403, accept_global_perms=accept_global_perms)

--- a/guardian/decorators.py
+++ b/guardian/decorators.py
@@ -59,6 +59,7 @@ def permission_required(perm, lookup_variables=None, **kwargs):
     redirect_field_name = kwargs.pop('redirect_field_name', REDIRECT_FIELD_NAME)
     return_403 = kwargs.pop('return_403', False)
     accept_global_perms = kwargs.pop('accept_global_perms', False)
+    user_specific = kwargs.pop('user_specific', False)
 
     # Check if perm is given as string in order not to decorate
     # view function itself which makes debugging harder
@@ -77,8 +78,8 @@ def permission_required(perm, lookup_variables=None, **kwargs):
                 if isinstance(model, basestring):
                     splitted = model.split('.')
                     if len(splitted) != 2:
-                        raise GuardianError("If model should be looked up from "
-                            "string it needs format: 'app_label.ModelClass'")
+                        raise GuardianError("If model should be looked up from"
+                            " string it needs format: 'app_label.ModelClass'")
                     model = get_model(*splitted)
                 elif issubclass(model.__class__, (Model, ModelBase, QuerySet)):
                     pass
@@ -98,12 +99,13 @@ def permission_required(perm, lookup_variables=None, **kwargs):
                     lookup_dict[lookup] = kwargs[view_arg]
                 obj = get_object_or_404(model, **lookup_dict)
 
-            if request.user.is_authenticated():
-                return_403 = True
+            _return_403 = return_403
+            if user_specific:
+                _return_403 = True if request.user.is_authenticated() else False
 
             response = get_403_or_None(request, perms=[perm], obj=obj,
                 login_url=login_url, redirect_field_name=redirect_field_name,
-                return_403=return_403, accept_global_perms=accept_global_perms)
+                return_403=_return_403, accept_global_perms=accept_global_perms)
             if response:
                 return response
             return view_func(request, *args, **kwargs)
@@ -115,8 +117,8 @@ def permission_required_or_403(perm, *args, **kwargs):
     """
     Simple wrapper for permission_required decorator.
 
-    Standard Django's permission_required decorator redirects user to login page
-    in case permission check failed. This decorator may be used to return
+    Standard Django's permission_required decorator redirects user to login
+    page in case permission check failed. This decorator may be used to return
     HttpResponseForbidden (status 403) instead of redirection.
 
     The only difference between ``permission_required`` decorator is that this
@@ -125,3 +127,17 @@ def permission_required_or_403(perm, *args, **kwargs):
     kwargs['return_403'] = True
     return permission_required(perm, *args, **kwargs)
 
+
+def permission_required_user_specific(perm, *args, **kwargs):
+    """
+    Simple wrapper for permission_required decorator.
+
+    First it will check permissions and if check failed, than returns
+    HttpResponseForbidden if user is already logged in, or redirects if user
+    isn't logged.
+
+    The only difference between ``permission_required`` decorator is that this
+    one always set ``user_specific`` parameter to ``True``.
+    """
+    kwargs['user_specific'] = True
+    return permission_required(perm, *args, **kwargs)

--- a/guardian/tests/decorators_test.py
+++ b/guardian/tests/decorators_test.py
@@ -15,7 +15,8 @@ from django.test import TestCase
 from guardian.compat import get_user_model
 from guardian.compat import get_user_model_path
 from guardian.compat import get_user_permission_full_codename
-from guardian.decorators import permission_required, permission_required_or_403
+from guardian.decorators import permission_required, \
+        permission_required_or_403, permission_required_user_specific
 from guardian.exceptions import GuardianError
 from guardian.exceptions import WrongAppError
 from guardian.shortcuts import assign_perm
@@ -354,3 +355,22 @@ class PermissionRequiredTest(TestDataMixin, TestCase):
         self.assertTrue(response._headers['location'][1].startswith(
             '/foobar/'))
 
+    def test_user_specific_anonymous(self):
+        request = self._get_request(self.anon)
+
+        @permission_required_user_specific('testapp.change_project')
+        def dummy_view(request):
+            pass
+
+        response = dummy_view(request)
+        self.assertEqual(response.status_code, 302)
+
+    def test_user_specific_logged(self):
+        request = self._get_request(self.user)
+
+        @permission_required_user_specific('testapp.change_project')
+        def dummy_view(request):
+            pass
+
+        response = dummy_view(request)
+        self.assertEqual(response.status_code, 403)


### PR DESCRIPTION
Hi,
I needed little modification and I wasn't able to do it without modification of ``django-guardian``. I didn't find way how to redirect anonymous users to login page and show ``HttpResponseForbidden`` for users, who are already logged in. So I made this patch.

It adds ``user_specific`` parameter to ``permission_required``. If ``user_specific`` is ``True``, than it will check if user is logged in. If it is so, and user hasn't enough permissions to view the page, error 403 is returned. If user isn't logged in and if anonymous users can't view the page, than he will be redirected to ``login_url``. 

By default, this option is disabled in ``permission_required``. So it keeps backward compatibility. For easier use, I add also ``permission_required_user_specific`` decorator, which is a shortcut to ``permission_required`` with ``user_specific`` parameter turned on.

I don't know, if it fits to django-guardian philosophy, but I posted it here, to save someone else time. 

P.S.: I don't know, if ``user_specific`` is the best name for this functionality. But I didn't find out better label.