### PR TITLE
Trying to fix deprecation warnings on Django 1.6.

### DIFF
--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -93,8 +93,9 @@ class Benchmark(object):
         self.objects_count = objects_count
         self.objects_with_perms_count = objects_with_perms_count
 
+        from guardian.compat import get_model_name
         self.Model = model
-        self.perm = 'auth.change_%s' % model._meta.model_name
+        self.perm = 'auth.change_%s' % get_model_name(model)
 
     def info(self, msg):
         print(colorize(msg + '\n', fg='green'))

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -94,7 +94,7 @@ class Benchmark(object):
         self.objects_with_perms_count = objects_with_perms_count
 
         self.Model = model
-        self.perm = 'auth.change_%s' % model._meta.module_name
+        self.perm = 'auth.change_%s' % model._meta.model_name
 
     def info(self, msg):
         print(colorize(msg + '\n', fg='green'))

--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django import forms
 from django.conf import settings
-from guardian.compat import url, patterns
+from guardian.compat import get_model_name, url, patterns
 from django.contrib import admin
 from django.contrib import messages
 from django.contrib.admin.widgets import FilteredSelectMultiple
@@ -92,7 +92,7 @@ class GuardedModelAdminMixin(object):
         """
         urls = super(GuardedModelAdminMixin, self).get_urls()
         if self.include_object_permissions_urls:
-            info = self.model._meta.app_label, self.model._meta.model_name
+            info = self.model._meta.app_label, get_model_name(self.model)
             myurls = patterns('',
                 url(r'^(?P<object_pk>.+)/permissions/$',
                     view=self.admin_site.admin_view(self.obj_perms_manage_view),
@@ -153,7 +153,7 @@ class GuardedModelAdminMixin(object):
             info = (
                 self.admin_site.name,
                 self.model._meta.app_label,
-                self.model._meta.model_name
+                get_model_name(self.model)
             )
             if user_form.is_valid():
                 user_id = user_form.cleaned_data['user'].id
@@ -168,7 +168,7 @@ class GuardedModelAdminMixin(object):
             info = (
                 self.admin_site.name,
                 self.model._meta.app_label,
-                self.model._meta.model_name
+                get_model_name(self.model)
             )
             if group_form.is_valid():
                 group_id = group_form.cleaned_data['group'].id
@@ -220,7 +220,7 @@ class GuardedModelAdminMixin(object):
             info = (
                 self.admin_site.name,
                 self.model._meta.app_label,
-                self.model._meta.model_name
+                get_model_name(self.model)
             )
             url = reverse(
                 '%s:%s_%s_permissions_manage_user' % info,
@@ -273,7 +273,7 @@ class GuardedModelAdminMixin(object):
             info = (
                 self.admin_site.name,
                 self.model._meta.app_label,
-                self.model._meta.model_name
+                get_model_name(self.model)
             )
             url = reverse(
                 '%s:%s_%s_permissions_manage_group' % info,

--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -60,8 +60,8 @@ class GuardedModelAdminMixin(object):
     group_owned_objects_field = 'group'
     include_object_permissions_urls = True
 
-    def queryset(self, request):
-        qs = super(GuardedModelAdminMixin, self).queryset(request)
+    def get_queryset(self, request):
+        qs = super(GuardedModelAdminMixin, self).get_queryset(request)
         if request.user.is_superuser:
             return qs
 
@@ -92,7 +92,7 @@ class GuardedModelAdminMixin(object):
         """
         urls = super(GuardedModelAdminMixin, self).get_urls()
         if self.include_object_permissions_urls:
-            info = self.model._meta.app_label, self.model._meta.module_name
+            info = self.model._meta.app_label, self.model._meta.model_name
             myurls = patterns('',
                 url(r'^(?P<object_pk>.+)/permissions/$',
                     view=self.admin_site.admin_view(self.obj_perms_manage_view),
@@ -136,7 +136,7 @@ class GuardedModelAdminMixin(object):
         shown. In order to add or manage user or group one should use links or
         forms presented within the page.
         """
-        obj = get_object_or_404(self.queryset(request), pk=object_pk)
+        obj = get_object_or_404(self.get_queryset(request), pk=object_pk)
         users_perms = SortedDict(
             get_users_with_perms(obj, attach_perms=True,
                 with_group_users=False))
@@ -153,7 +153,7 @@ class GuardedModelAdminMixin(object):
             info = (
                 self.admin_site.name,
                 self.model._meta.app_label,
-                self.model._meta.module_name
+                self.model._meta.model_name
             )
             if user_form.is_valid():
                 user_id = user_form.cleaned_data['user'].id
@@ -168,7 +168,7 @@ class GuardedModelAdminMixin(object):
             info = (
                 self.admin_site.name,
                 self.model._meta.app_label,
-                self.model._meta.module_name
+                self.model._meta.model_name
             )
             if group_form.is_valid():
                 group_id = group_form.cleaned_data['group'].id
@@ -209,7 +209,7 @@ class GuardedModelAdminMixin(object):
         Manages selected users' permissions for current object.
         """
         user = get_object_or_404(get_user_model(), id=user_id)
-        obj = get_object_or_404(self.queryset(request), pk=object_pk)
+        obj = get_object_or_404(self.get_queryset(request), pk=object_pk)
         form_class = self.get_obj_perms_manage_user_form()
         form = form_class(user, obj, request.POST or None)
 
@@ -220,7 +220,7 @@ class GuardedModelAdminMixin(object):
             info = (
                 self.admin_site.name,
                 self.model._meta.app_label,
-                self.model._meta.module_name
+                self.model._meta.model_name
             )
             url = reverse(
                 '%s:%s_%s_permissions_manage_user' % info,
@@ -262,7 +262,7 @@ class GuardedModelAdminMixin(object):
         Manages selected groups' permissions for current object.
         """
         group = get_object_or_404(Group, id=group_id)
-        obj = get_object_or_404(self.queryset(request), pk=object_pk)
+        obj = get_object_or_404(self.get_queryset(request), pk=object_pk)
         form_class = self.get_obj_perms_manage_group_form()
         form = form_class(group, obj, request.POST or None)
 
@@ -273,7 +273,7 @@ class GuardedModelAdminMixin(object):
             info = (
                 self.admin_site.name,
                 self.model._meta.app_label,
-                self.model._meta.module_name
+                self.model._meta.model_name
             )
             url = reverse(
                 '%s:%s_%s_permissions_manage_group' % info,

--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -60,8 +60,21 @@ class GuardedModelAdminMixin(object):
     group_owned_objects_field = 'group'
     include_object_permissions_urls = True
 
+    def queryset(self, request):
+        """
+        This method has been renamed to get_queryset in Django 1.6.
+        """
+        return self.get_queryset(request)
+
     def get_queryset(self, request):
-        qs = super(GuardedModelAdminMixin, self).get_queryset(request)
+        super_class = super(GuardedModelAdminMixin, self)
+        if hasattr(super_class, 'get_queryset'):
+            # Django 1.6 or later.
+            qs = super_class.get_queryset(request)
+        else:
+            # Django 1.5 or earlier.
+            qs = super_class.queryset(request)
+
         if request.user.is_superuser:
             return qs
 

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -18,6 +18,7 @@ __all__ = [
     'Group',
     'Permission',
     'AnonymousUser',
+    'get_model_name',
     'get_user_model',
     'import_string',
     'user_model_label',
@@ -73,7 +74,7 @@ def get_user_permission_full_codename(perm):
     ``myapp.CustomUser`` is used it would return ``myapp.change_customuser``.
     """
     User = get_user_model()
-    return '%s.%s_%s' % (User._meta.app_label, perm, User._meta.model_name)
+    return '%s.%s_%s' % (User._meta.app_label, perm, get_model_name(User))
 
 def get_user_permission_codename(perm):
     """
@@ -129,3 +130,14 @@ def create_permissions(*args, **kwargs):
     return original_create_permissions(*args, **kwargs)
 
 __all__ = ['User', 'Group', 'Permission', 'AnonymousUser']
+
+
+def get_model_name(model):
+    """
+    Returns model._meta.model_name on Django >=1.6 or model._meta.module_name
+    on earlier versions.
+    """
+    if hasattr(model._meta, 'model_name'):
+        return model._meta.model_name
+    else:
+        return model._meta.module_name

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -73,7 +73,7 @@ def get_user_permission_full_codename(perm):
     ``myapp.CustomUser`` is used it would return ``myapp.change_customuser``.
     """
     User = get_user_model()
-    return '%s.%s_%s' % (User._meta.app_label, perm, User._meta.module_name)
+    return '%s.%s_%s' % (User._meta.app_label, perm, User._meta.model_name)
 
 def get_user_permission_codename(perm):
     """

--- a/guardian/testapp/tests/admin_test.py
+++ b/guardian/testapp/tests/admin_test.py
@@ -11,6 +11,7 @@ from django.test import TestCase
 from django.test.client import Client
 
 from guardian.admin import GuardedModelAdmin
+from guardian.compat import get_model_name
 from guardian.compat import get_user_model
 from guardian.compat import str
 from guardian.shortcuts import get_perms
@@ -43,7 +44,7 @@ class AdminTests(TestCase):
         self.client = Client()
         self.obj = ContentType.objects.create(name='foo', model='bar',
             app_label='fake-for-guardian-tests')
-        self.obj_info = self.obj._meta.app_label, self.obj._meta.model_name
+        self.obj_info = self.obj._meta.app_label, get_model_name(self.obj)
 
     def tearDown(self):
         self.client.logout()

--- a/guardian/testapp/tests/admin_test.py
+++ b/guardian/testapp/tests/admin_test.py
@@ -43,7 +43,7 @@ class AdminTests(TestCase):
         self.client = Client()
         self.obj = ContentType.objects.create(name='foo', model='bar',
             app_label='fake-for-guardian-tests')
-        self.obj_info = self.obj._meta.app_label, self.obj._meta.module_name
+        self.obj_info = self.obj._meta.app_label, self.obj._meta.model_name
 
     def tearDown(self):
         self.client.logout()
@@ -343,7 +343,7 @@ class GuardedModelAdminTests(TestCase):
             object_id=jane.id, action_flag=1, change_message='bar')
         request = HttpRequest()
         request.user = joe
-        qs = gma.queryset(request)
+        qs = gma.get_queryset(request)
         self.assertEqual([e.pk for e in qs], [joe_entry.pk])
 
     def test_user_can_acces_owned_objects_only_unless_superuser(self):
@@ -361,7 +361,7 @@ class GuardedModelAdminTests(TestCase):
             object_id=jane.id, action_flag=1, change_message='bar')
         request = HttpRequest()
         request.user = joe
-        qs = gma.queryset(request)
+        qs = gma.get_queryset(request)
         self.assertEqual(sorted([e.pk for e in qs]),
             sorted([joe_entry.pk, jane_entry.pk]))
 
@@ -387,7 +387,7 @@ class GuardedModelAdminTests(TestCase):
             group=joe_group)
         request = HttpRequest()
         request.user = joe
-        qs = gma.queryset(request)
+        qs = gma.get_queryset(request)
         self.assertEqual([e.pk for e in qs], [joe_entry_group.pk])
 
     def test_user_can_access_owned_by_group_objects_only_unless_superuser(self):
@@ -415,7 +415,7 @@ class GuardedModelAdminTests(TestCase):
             group=jane_group)
         request = HttpRequest()
         request.user = joe
-        qs = gma.queryset(request)
+        qs = gma.get_queryset(request)
         self.assertEqual(sorted(e.pk for e in qs),
             sorted(LogEntry.objects.values_list('pk', flat=True)))
 

--- a/guardian/testapp/tests/orphans_test.py
+++ b/guardian/testapp/tests/orphans_test.py
@@ -18,7 +18,7 @@ from guardian.testapp.tests.conf import skipUnlessTestApp
 
 
 User = get_user_model()
-user_module_name = User._meta.module_name
+user_model_name = User._meta.model_name
 
 @skipUnlessTestApp
 class OrphanedObjectPermissionsTest(TestCase):
@@ -42,7 +42,7 @@ class OrphanedObjectPermissionsTest(TestCase):
 
         # assign obj perms
         target_perms = {
-            self.target_user1: ["change_%s" % user_module_name],
+            self.target_user1: ["change_%s" % user_model_name],
             self.target_group1: ["delete_group"],
             self.target_obj1: ["change_contenttype", "delete_contenttype"],
             self.target_obj2: ["change_contenttype"],
@@ -76,7 +76,7 @@ class OrphanedObjectPermissionsTest(TestCase):
 
         # assign obj perms
         target_perms = {
-            self.target_user1: ["change_%s" % user_module_name],
+            self.target_user1: ["change_%s" % user_model_name],
             self.target_group1: ["delete_group"],
             self.target_obj1: ["change_contenttype", "delete_contenttype"],
             self.target_obj2: ["change_contenttype"],

--- a/guardian/testapp/tests/orphans_test.py
+++ b/guardian/testapp/tests/orphans_test.py
@@ -10,7 +10,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.management import call_command
 from django.test import TestCase
 
-from guardian.compat import get_user_model, create_permissions
+from guardian.compat import get_model_name, get_user_model, create_permissions
 from guardian.utils import clean_orphan_obj_perms
 from guardian.shortcuts import assign_perm
 from guardian.models import Group
@@ -18,7 +18,7 @@ from guardian.testapp.tests.conf import skipUnlessTestApp
 
 
 User = get_user_model()
-user_model_name = User._meta.model_name
+user_model_name = get_model_name(User)
 
 @skipUnlessTestApp
 class OrphanedObjectPermissionsTest(TestCase):

--- a/guardian/testapp/tests/shortcuts_test.py
+++ b/guardian/testapp/tests/shortcuts_test.py
@@ -28,7 +28,7 @@ import warnings
 
 User = get_user_model()
 user_app_label = User._meta.app_label
-user_module_name = User._meta.module_name
+user_model_name = User._meta.model_name
 
 class ShortcutsTests(ObjectPermissionTestCase):
 
@@ -268,7 +268,7 @@ class GetUsersWithPermsTest(TestCase):
         assign_perm("delete_contenttype", self.user2, self.obj1)
         assign_perm("delete_contenttype", self.user2, self.obj2)
         assign_perm("change_contenttype", self.user3, self.obj2)
-        assign_perm("change_%s" % user_module_name, self.user3, self.user1)
+        assign_perm("change_%s" % user_model_name, self.user3, self.user1)
 
         result = get_users_with_perms(self.obj1)
         self.assertEqual(
@@ -377,11 +377,11 @@ class GetGroupsWithPerms(TestCase):
     def test_mixed(self):
         assign_perm("change_contenttype", self.group1, self.obj1)
         assign_perm("change_contenttype", self.group1, self.obj2)
-        assign_perm("change_%s" % user_module_name, self.group1, self.user3)
+        assign_perm("change_%s" % user_model_name, self.group1, self.user3)
         assign_perm("change_contenttype", self.group2, self.obj2)
         assign_perm("change_contenttype", self.group2, self.obj1)
         assign_perm("delete_contenttype", self.group2, self.obj1)
-        assign_perm("change_%s" % user_module_name, self.group3, self.user1)
+        assign_perm("change_%s" % user_model_name, self.group3, self.user1)
 
         result = get_groups_with_perms(self.obj1)
         self.assertEqual(set(result), set([self.group1, self.group2]))

--- a/guardian/testapp/tests/shortcuts_test.py
+++ b/guardian/testapp/tests/shortcuts_test.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 
 from guardian.shortcuts import get_perms_for_model
 from guardian.core import ObjectPermissionChecker
+from guardian.compat import get_model_name
 from guardian.compat import get_user_model
 from guardian.compat import get_user_permission_full_codename
 from guardian.shortcuts import assign
@@ -28,7 +29,7 @@ import warnings
 
 User = get_user_model()
 user_app_label = User._meta.app_label
-user_model_name = User._meta.model_name
+user_model_name = get_model_name(User)
 
 class ShortcutsTests(ObjectPermissionTestCase):
 


### PR DESCRIPTION
Tries to fix https://github.com/lukaszb/django-guardian/issues/207

Those warnings were introduced in
https://github.com/django/django/commit/6983a1a540a6e6c3bd941fa15ddd8cb49f9ec74e
https://code.djangoproject.com/ticket/15363
https://docs.djangoproject.com/en/1.7/releases/1.6/#get-query-set-and-similar-methods-renamed-to-get-queryset
https://docs.djangoproject.com/en/1.7/releases/1.6/#module-name-model-meta-attribute

Unfortunately, while testing with Python 3.3 and Django 1.6.3, I
couldn't make the tests fail. All 198 tests kept passing both before and
after this commit. I ran the tests usin `python3 setup.py test`.