### PR TITLE
Update assign.rst - syncdb is not enough

### DIFF
--- a/docs/userguide/assign.rst
+++ b/docs/userguide/assign.rst
@@ -36,7 +36,7 @@ model could look like:
                 ('view_task', 'View task'),
             )
 
-After we call ``syncdb`` management command our *view_task* permission would be
+After we call ``syncdb --all`` management command our *view_task* permission would be
 added to default set of permissions.
 
 .. note::


### PR DESCRIPTION
source: http://stackoverflow.com/questions/19277543/working-with-django-model-permission-raises-doesnotexist-error
new permissions are not created in Django 1.4.10 with default syncdb