### PR TITLE
implemented global permission check in shortcuts for get_objects_for_use...

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,3 +51,4 @@ Authors ordered by first contribution
 - Brian May <brian@microcomaustralia.com.au>
 - Troy Grosfield <troy.grosfield@gmail.com>
 - Michael Drescher <kaesemeister@gmail.com>
+- Verena Jaspersen <verena.jaspersen@gmail.com>

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -285,7 +285,7 @@ def get_groups_with_perms(obj, attach_perms=False):
 
 
 def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=False,
-        with_superuser=True):
+        with_superuser=True, accept_global_perms=True):
     """
     Returns queryset of objects for which a given ``user`` has *all*
     permissions present at ``perms``.
@@ -302,9 +302,14 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
       this parameter would be computed based on given ``params``.
     :param use_groups: if ``False``, wouldn't check user's groups object
       permissions. Default is ``True``.
-    :param any_perm: if True, any of permission in sequence is accepted
+    :param any_perm: if True, any of permission in sequence is accepted. Default is ``False``.
     :param with_superuser: if ``True`` returns the entire queryset if not it will
-    only return objects the user has explicit permissions.
+    only return objects the user has explicit permissions. Default is ``True``.
+    :param accept_global_perms: if ``True`` takes global permissions into account.
+      Object based permissions are taken into account if more than one permission is handed in in perms and at least
+      one of these perms is not globally set. If any_perm is set to false then the intersection of matching object
+      is returned. Note, that if with_superuser is False, accept_global_perms will be ignored, which means that only
+      object permissions will be checked! Default is ``True``.
 
     :raises MixedContentTypeError: when computed content type for ``perms``
       and/or ``klass`` clashes.
@@ -324,6 +329,7 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
         >>> get_objects_for_user(joe, 'auth.change_group')
         [<Group some group>]
 
+
     The permission string can also be an iterable. Continuing with the previous example:
 
         >>> get_objects_for_user(joe, ['auth.change_group', 'auth.delete_group'])
@@ -333,6 +339,18 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
         >>> assign_perm('auth.delete_group', joe, group)
         >>> get_objects_for_user(joe, ['auth.change_group', 'auth.delete_group'])
         [<Group some group>]
+
+    Take global permissions into account:
+        >>> jack = User.objects.get(username='jack')
+        >>> assign_perm('auth.change_group', jack) # this will set a global permission
+        >>> get_objects_for_user(jack, 'auth.change_group')
+        [<Group some group>]
+        >>> group2 = Group.objects.create('other group')
+        >>> assign_perm('auth.delete_group', jack, group2)
+        >>> get_objects_for_user(jack, ['auth.change_group', 'auth.delete_group']) # this retrieves intersection
+        [<Group other group>]
+        >>> get_objects_for_user(jack, ['auth.change_group', 'auth.delete_group'], any_perm) # this retrieves union
+        [<Group some group>, <Group other group>]
 
     """
     if isinstance(perms, basestring):
@@ -390,6 +408,33 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
     if user.is_anonymous():
         user = get_anonymous_user()
 
+    global_perms = set()
+    has_global_perms = False
+    # a superuser has by default assigned global perms for any
+    if accept_global_perms and with_superuser:
+        for code in codenames:
+            if user.has_perm(app_label + '.' + code):
+                global_perms.add(code)
+        for code in global_perms:
+            codenames.remove(code)
+        ## prerequisite: there must be elements in global_perms otherwise just follow the procedure for
+        # object based permissions only AND
+        # 1. codenames is empty, which means that permissions are ONLY set globally, therefore return the full queryset.
+        # OR
+        # 2. any_perm is True, then the global permission beats the object based permission anyway,
+        # therefore return full queryset
+        if len(global_perms) > 0 and (len(codenames) == 0 or any_perm):
+            return queryset
+        # if we have global perms and still some object based perms differing from global perms and any_perm is set
+        # to false, then we have to flag that global perms exist in order to merge object based permissions by user
+        # and by group correctly. Scenario: global perm change_xx and object based perm delete_xx on object A for user,
+        # and object based permission delete_xx  on object B for group, to which user is assigned.
+        # get_objects_for_user(user, [change_xx, delete_xx], use_groups=True, any_perm=False, accept_global_perms=True)
+        # must retrieve object A and B.
+        elif len(global_perms) > 0 and (len(codenames) > 0):
+            has_global_perms = True
+
+
     # Now we should extract list of pk values for which we would filter queryset
     user_model = get_user_obj_perms_model(queryset.model)
     user_obj_perms_queryset = (user_model.objects
@@ -413,7 +458,7 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
             fields = ['object_pk', 'permission__codename']
         else:
             fields = ['content_object__pk', 'permission__codename']
-        if not any_perm:
+        if not any_perm and not has_global_perms:
             user_obj_perms = user_obj_perms_queryset.values_list(*fields)
             groups_obj_perms = groups_obj_perms_queryset.values_list(*fields)
             data = list(user_obj_perms) + list(groups_obj_perms)
@@ -444,7 +489,7 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
     return objects
 
 
-def get_objects_for_group(group, perms, klass=None, any_perm=False):
+def get_objects_for_group(group, perms, klass=None, any_perm=False, accept_global_perms=True):
     """
     Returns queryset of objects for which a given ``group`` has *all*
     permissions present at ``perms``.
@@ -459,6 +504,9 @@ def get_objects_for_group(group, perms, klass=None, any_perm=False):
     :param klass: may be a Model, Manager or QuerySet object. If not given
       this parameter would be computed based on given ``params``.
     :param any_perm: if True, any of permission in sequence is accepted
+    :param accept_global_perms: if ``True`` takes global permissions into account.
+      If any_perm is set to false then the intersection of matching objects based on global and object based permissions
+      is returned. Default is ``True``.
 
     :raises MixedContentTypeError: when computed content type for ``perms``
       and/or ``klass`` clashes.
@@ -487,6 +535,14 @@ def get_objects_for_group(group, perms, klass=None, any_perm=False):
         []
         >>> assign_perm('tasker.delete_task', group, task)
         >>> get_objects_for_group(group, ['tasker.add_task', 'tasker.delete_task'])
+        [<Task some task>]
+
+    Global permissions assigned to the group are also taken into account. Continuing with previous example:
+        >>> task_other = Task.objects.create('other task')
+        >>> assign_perm('tasker.change_task', group)
+        >>> get_objects_for_group(group, ['tasker.change_task'])
+        [<Task some task>, <Task other task>]
+        >>> get_objects_for_group(group, ['tasker.change_task'], accept_global_perms=False)
         [<Task some task>]
 
     """
@@ -535,6 +591,17 @@ def get_objects_for_group(group, perms, klass=None, any_perm=False):
     # match which means: ctype.model_class() == queryset.model
     # we should also have ``codenames`` list
 
+    global_perms = set()
+    if accept_global_perms:
+        global_perm_set = group.permissions.values_list('codename', flat=True)
+        for code in codenames:
+            if code in global_perm_set:
+                global_perms.add(code)
+        for code in global_perms:
+            codenames.remove(code)
+        if len(global_perms) > 0 and (len(codenames) == 0 or any_perm):
+            return queryset
+
     # Now we should extract list of pk values for which we would filter queryset
     group_model = get_group_obj_perms_model(queryset.model)
     groups_obj_perms_queryset = (group_model.objects
@@ -555,6 +622,5 @@ def get_objects_for_group(group, perms, klass=None, any_perm=False):
         obj_codenames = set((e[1] for e in group))
         if any_perm or codenames.issubset(obj_codenames):
             pk_list.append(pk)
-
     objects = queryset.filter(pk__in=pk_list)
     return objects

--- a/guardian/testapp/tests/shortcuts_test.py
+++ b/guardian/testapp/tests/shortcuts_test.py
@@ -476,10 +476,12 @@ class GetObjectsForUser(TestCase):
             ['change_group'])
 
     def test_empty_perms_sequence(self):
+        objects = get_objects_for_user(self.user, [], Group.objects.all())
         self.assertEqual(
-            set(get_objects_for_user(self.user, [], Group.objects.all())),
+            set(objects),
             set()
         )
+
 
     def test_perms_single(self):
         perm = 'auth.change_group'
@@ -578,7 +580,7 @@ class GetObjectsForUser(TestCase):
 
         # Objects to operate on
         ctypes = list(ContentType.objects.all().order_by('id'))
-
+        assign_perm('auth.change_group', self.user)
         assign_perm('change_contenttype', self.user, ctypes[0])
         assign_perm('change_contenttype', self.user, ctypes[1])
         assign_perm('delete_contenttype', self.user, ctypes[1])
@@ -607,6 +609,113 @@ class GetObjectsForUser(TestCase):
         self.assertEqual(
             set(objects.values_list('id', flat=True)),
             set(ctypes[i].id for i in [0, 1, 3, 4]))
+
+    def test_has_global_permission_only(self):
+        group_names = ['group1', 'group2', 'group3']
+        groups = [Group.objects.create(name=name) for name in group_names]
+        #global permission to change any group
+        perm = 'auth.change_group'
+
+        assign_perm(perm, self.user)
+        objects = get_objects_for_user(self.user, perm)
+        remove_perm(perm, self.user)
+        self.assertEqual(set(objects),
+                         set(Group.objects.all()))
+
+    def test_has_global_permission_and_object_based_permission(self):
+        group_names = ['group1', 'group2', 'group3']
+        groups = [Group.objects.create(name=name) for name in group_names]
+        #global permission to change any group
+        perm_global = 'auth.change_group'
+        perm_obj = 'delete_group'
+        assign_perm(perm_global, self.user)
+        assign_perm(perm_obj, self.user, groups[0])
+        objects = get_objects_for_user(self.user, [perm_global, perm_obj])
+        remove_perm(perm_global, self.user)
+        self.assertEqual(set(objects.values_list('name', flat=True)),
+                         set([groups[0].name]))
+
+    def test_has_global_permission_and_object_based_permission_any_perm(self):
+        group_names = ['group1', 'group2', 'group3']
+        groups = [Group.objects.create(name=name) for name in group_names]
+        #global permission to change any group
+        perm_global = 'auth.change_group'
+        #object based permission to change only a specific group
+        perm_obj = 'auth.delete_group'
+        assign_perm(perm_global, self.user)
+        assign_perm(perm_obj, self.user, groups[0])
+        objects = get_objects_for_user(self.user, [perm_global, perm_obj], any_perm=True, accept_global_perms=True)
+        remove_perm(perm_global, self.user)
+        self.assertEqual(set(objects),
+                         set(Group.objects.all()))
+
+    def test_object_based_permission_without_global_permission(self):
+        group_names = ['group1', 'group2', 'group3']
+        groups = [Group.objects.create(name=name) for name in group_names]
+        #global permission to delete any group
+        perm_global = 'auth.delete_group'
+        perm_obj = 'auth.delete_group'
+        assign_perm(perm_global, self.user)
+        assign_perm(perm_obj, self.user, groups[0])
+        objects = get_objects_for_user(self.user, [perm_obj], accept_global_perms=False)
+        remove_perm(perm_global, self.user)
+        self.assertEqual(set(objects.values_list('name', flat=True)),
+                         set([groups[0].name]))
+
+    def test_object_based_permission_with_groups_2perms(self):
+        group_names = ['group1', 'group2', 'group3']
+        groups = [Group.objects.create(name=name) for name in group_names]
+        for group in groups:
+            self.user.groups.add(group)
+        # Objects to operate on
+        ctypes = list(ContentType.objects.all().order_by('id'))
+        assign_perm('contenttypes.change_contenttype', self.user)
+        assign_perm('change_contenttype', self.user, ctypes[0])
+        assign_perm('change_contenttype', self.user, ctypes[1])
+        assign_perm('delete_contenttype', self.user, ctypes[1])
+        assign_perm('delete_contenttype', self.user, ctypes[2])
+
+        assign_perm('change_contenttype', groups[0], ctypes[3])
+        assign_perm('change_contenttype', groups[1], ctypes[3])
+        assign_perm('change_contenttype', groups[2], ctypes[4])
+        assign_perm('delete_contenttype', groups[0], ctypes[0])
+
+        objects = get_objects_for_user(self.user,
+            ['contenttypes.change_contenttype',
+            'contenttypes.delete_contenttype'], accept_global_perms=True)
+        self.assertEqual(
+            set(objects.values_list('id', flat=True)),
+            set([ctypes[0].id, ctypes[1].id, ctypes[2].id]))
+
+    def test_object_based_permission_with_groups_3perms(self):
+
+        group_names = ['group1', 'group2', 'group3']
+        groups = [Group.objects.create(name=name) for name in group_names]
+        for group in groups:
+            self.user.groups.add(group)
+        # Objects to operate on
+        ctypes = list(ContentType.objects.all().order_by('id'))
+        assign_perm('contenttypes.change_contenttype', self.user)
+        assign_perm('change_contenttype', self.user, ctypes[0])
+        assign_perm('change_contenttype', self.user, ctypes[1])
+        assign_perm('delete_contenttype', self.user, ctypes[1])
+        assign_perm('delete_contenttype', self.user, ctypes[2])
+        # add_contenttype does not make sense, here just for testing purposes, to also cover one if branch in function.
+        assign_perm('add_contenttype', self.user, ctypes[1])
+
+        assign_perm('change_contenttype', groups[0], ctypes[3])
+        assign_perm('change_contenttype', groups[1], ctypes[3])
+        assign_perm('change_contenttype', groups[2], ctypes[4])
+        assign_perm('delete_contenttype', groups[0], ctypes[0])
+        assign_perm('add_contenttype', groups[0], ctypes[0])
+
+        objects = get_objects_for_user(self.user,
+            ['contenttypes.change_contenttype',
+            'contenttypes.delete_contenttype', 'contenttypes.add_contenttype'], accept_global_perms=True)
+        self.assertEqual(
+            set(objects.values_list('id', flat=True)),
+            set([ctypes[0].id, ctypes[1].id]))
+
 
     def test_non_integer_primary_key(self):
         """
@@ -660,6 +769,10 @@ class GetObjectsForUser(TestCase):
         self.assertEqual(
             set(objects.values_list('pk', flat=True)),
             set([obj_with_char_pk.pk]))
+
+    def test_exception_different_ctypes(self):
+         self.assertRaises(MixedContentTypeError, get_objects_for_user,
+            self.user, ['auth.change_permission', 'auth.change_group'])
 
 
 class GetObjectsForGroup(TestCase):
@@ -795,3 +908,39 @@ class GetObjectsForGroup(TestCase):
         self.assertEqual(set(get_objects_for_group(self.group2, 'contenttypes.delete_contenttype')),
             set([self.obj2]))
 
+    def test_has_global_permission(self):
+        assign_perm('contenttypes.change_contenttype', self.group1)
+
+        objects = get_objects_for_group(self.group1, ['contenttypes.change_contenttype'])
+        self.assertEquals(set(objects),
+                          set(ContentType.objects.all()))
+
+    def test_has_global_permission_and_object_based_permission(self):
+        assign_perm('contenttypes.change_contenttype', self.group1)
+        assign_perm('contenttypes.delete_contenttype', self.group1, self.obj1)
+
+        objects = get_objects_for_group(self.group1, ['contenttypes.change_contenttype', 'contenttypes.delete_contenttype'], any_perm=False)
+        self.assertEquals(set(objects),
+                          set([self.obj1]))
+
+    def test_has_global_permission_and_object_based_permission_any_perm(self):
+        assign_perm('contenttypes.change_contenttype', self.group1)
+        assign_perm('contenttypes.delete_contenttype', self.group1, self.obj1)
+
+        objects = get_objects_for_group(self.group1, ['contenttypes.change_contenttype', 'contenttypes.delete_contenttype'], any_perm=True)
+        self.assertEquals(set(objects),
+                          set(ContentType.objects.all()))
+
+    def test_has_global_permission_and_object_based_permission_3perms(self):
+        assign_perm('contenttypes.change_contenttype', self.group1)
+        assign_perm('contenttypes.delete_contenttype', self.group1, self.obj1)
+        assign_perm('contenttypes.add_contenttype', self.group1, self.obj2)
+
+
+        objects = get_objects_for_group(self.group1, ['contenttypes.change_contenttype', 'contenttypes.delete_contenttype',  'contenttypes.add_contenttype'], any_perm=False)
+        self.assertEquals(set(objects),
+                          set())
+
+    def test_exception_different_ctypes(self):
+         self.assertRaises(MixedContentTypeError, get_objects_for_group,
+            self.group1, ['auth.change_permission', 'auth.change_group'])


### PR DESCRIPTION
...r and get_objects_for_group

I implemented the checks directly within the functions. But: shouldn't this be inherently implemented in ObjectPermissionChecker.has_perm function? I am not sure, what side effects this would have, and if this is desired at all..
