### PR TITLE
Use importlib and import GenericForeignKey from from django.contrib.contenttypes.fields

### DIFF
--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -4,9 +4,13 @@ from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.auth.models import Permission
 from django.contrib.auth.models import AnonymousUser
-from django.utils.importlib import import_module
 import six
 import sys
+
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
 try:
     from django.conf.urls import url, patterns, include, handler404, handler500

--- a/guardian/models.py
+++ b/guardian/models.py
@@ -5,7 +5,12 @@ from django.core.exceptions import ValidationError
 from django.contrib.auth.models import Group
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes.generic import GenericForeignKey
+
+try:
+    from django.contrib.contenttypes.fields import GenericForeignKey
+except ImportError:
+    from django.contrib.contenttypes.generic import GenericForeignKey
+
 from django.utils.translation import ugettext_lazy as _
 
 from guardian.compat import user_model_label


### PR DESCRIPTION
Importlib is included in Python 2.7, and will be dropped in Django 1.9 as it is no longer needed

django.contrib.contenttypes.generic will be removed in Django 1.9 and has been replaced by
fields, forms, and admin submodules instead of generic.

This should hopefully fix: #309
Kinda hard to test when all the Django 1.8 stuff ain't working yet. I'll fix it if there is a need to after the Django 1.8 pull-requests are merged :)